### PR TITLE
Implement LLM sentiment pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# Ai_Search_Summerize
+# Ai Search Summarize
+
+This project demonstrates a pipeline for fine-tuning a language model for sentiment
+classification and generating context-aware responses.
+
+The code includes:
+- Data loading utilities using the IMDB dataset.
+- A parameter-efficient LoRA fine-tuning setup for a DistilBERT classifier.
+- Training script with Hugging Face Transformers `Trainer`.
+- A FAISS-based retrieval component built with sentence-transformers.
+- A text generation module that augments prompts with retrieved context.
+- A simple Streamlit application that ties everything together.
+
+Install dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
+Then run the Streamlit app:
+
+```bash
+streamlit run src/app.py
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+transformers
+datasets
+peft
+sentence-transformers
+faiss-cpu
+streamlit
+torch

--- a/src/app.py
+++ b/src/app.py
@@ -1,0 +1,28 @@
+import streamlit as st
+
+from generate import ContextAwareGenerator
+from train import main as train_model
+
+
+st.title("Sentiment + Contextual Response App")
+
+if "generator" not in st.session_state:
+    st.session_state.generator = ContextAwareGenerator()
+
+text_input = st.text_input("Enter your query")
+
+if st.button("Train Model"):
+    st.write("Training... (this may take a while)")
+    train_model()
+    st.success("Training complete")
+
+if st.button("Build Retrieval"):
+    st.session_state.generator.build_retrieval(["Example document 1", "Example document 2"])
+    st.success("Retrieval built")
+
+if st.button("Generate Response"):
+    if text_input:
+        response = st.session_state.generator.generate(text_input)
+        st.write(response)
+    else:
+        st.warning("Please enter text")

--- a/src/data.py
+++ b/src/data.py
@@ -1,0 +1,14 @@
+from datasets import load_dataset
+from transformers import AutoTokenizer
+
+
+def load_data(split: str = "train", sample_size: int = 10000):
+    """Load and tokenize a subset of the IMDB dataset."""
+    dataset = load_dataset("imdb", split=split)
+    if sample_size:
+        dataset = dataset.shuffle(seed=42).select(range(sample_size))
+    return dataset
+
+
+def get_tokenizer(model_name: str = "distilbert-base-uncased"):
+    return AutoTokenizer.from_pretrained(model_name)

--- a/src/generate.py
+++ b/src/generate.py
@@ -1,0 +1,18 @@
+from transformers import pipeline
+
+from retrieval import Retriever
+
+
+class ContextAwareGenerator:
+    def __init__(self, model_name: str = "gpt2"):
+        self.generator = pipeline("text-generation", model=model_name)
+        self.retriever = Retriever()
+
+    def build_retrieval(self, documents):
+        self.retriever.build_index(documents)
+
+    def generate(self, query: str, top_k: int = 3, max_new_tokens: int = 50):
+        context_docs = self.retriever.query(query, top_k=top_k)
+        prompt = query + "\n" + "\n".join(context_docs)
+        outputs = self.generator(prompt, max_new_tokens=max_new_tokens)
+        return outputs[0]["generated_text"]

--- a/src/model.py
+++ b/src/model.py
@@ -1,0 +1,20 @@
+from transformers import AutoModelForSequenceClassification
+from peft import get_peft_model, LoraConfig, TaskType
+
+
+MODEL_NAME = "distilbert-base-uncased"
+
+
+def load_model(num_labels: int = 2):
+    base_model = AutoModelForSequenceClassification.from_pretrained(
+        MODEL_NAME, num_labels=num_labels
+    )
+    peft_config = LoraConfig(
+        task_type=TaskType.SEQ_CLS,
+        inference_mode=False,
+        r=8,
+        lora_alpha=16,
+        lora_dropout=0.1,
+    )
+    model = get_peft_model(base_model, peft_config)
+    return model

--- a/src/retrieval.py
+++ b/src/retrieval.py
@@ -1,0 +1,23 @@
+from typing import List
+import faiss
+from sentence_transformers import SentenceTransformer
+
+
+class Retriever:
+    def __init__(self, model_name: str = "all-MiniLM-L6-v2"):
+        self.embedder = SentenceTransformer(model_name)
+        self.index = None
+        self.corpus = []
+
+    def build_index(self, documents: List[str]):
+        self.corpus = documents
+        embeddings = self.embedder.encode(documents, convert_to_tensor=False)
+        self.index = faiss.IndexFlatL2(embeddings.shape[1])
+        self.index.add(embeddings)
+
+    def query(self, text: str, top_k: int = 3) -> List[str]:
+        if self.index is None:
+            raise ValueError("Index not built")
+        embedding = self.embedder.encode([text], convert_to_tensor=False)
+        distances, indices = self.index.search(embedding, top_k)
+        return [self.corpus[i] for i in indices[0]]

--- a/src/train.py
+++ b/src/train.py
@@ -1,0 +1,59 @@
+import os
+from typing import Optional
+
+import torch
+from datasets import load_metric
+from transformers import (AutoTokenizer, DataCollatorWithPadding, Trainer,
+                          TrainingArguments)
+
+from data import load_data, get_tokenizer
+from model import load_model, MODEL_NAME
+
+
+def tokenize_function(examples, tokenizer):
+    return tokenizer(examples["text"], truncation=True)
+
+
+def main(output_dir: str = "./checkpoint", sample_size: int = 1000):
+    dataset = load_data(sample_size=sample_size)
+    tokenizer = get_tokenizer(MODEL_NAME)
+    tokenized_dataset = dataset.map(lambda x: tokenize_function(x, tokenizer), batched=True)
+
+    data_collator = DataCollatorWithPadding(tokenizer=tokenizer)
+    model = load_model()
+
+    training_args = TrainingArguments(
+        output_dir=output_dir,
+        num_train_epochs=1,
+        per_device_train_batch_size=8,
+        per_device_eval_batch_size=8,
+        evaluation_strategy="epoch",
+        save_strategy="epoch",
+        learning_rate=1e-4,
+        fp16=torch.cuda.is_available(),
+        logging_steps=10,
+    )
+
+    metric = load_metric("accuracy")
+
+    def compute_metrics(eval_pred):
+        predictions, labels = eval_pred
+        preds = predictions.argmax(-1)
+        return metric.compute(predictions=preds, references=labels)
+
+    trainer = Trainer(
+        model=model,
+        args=training_args,
+        train_dataset=tokenized_dataset,
+        eval_dataset=tokenized_dataset,
+        tokenizer=tokenizer,
+        data_collator=data_collator,
+        compute_metrics=compute_metrics,
+    )
+
+    trainer.train()
+    trainer.save_model(output_dir)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add requirements for transformers, PEFT and Streamlit
- create data loader and tokenizer helper
- implement LoRA-based DistilBERT classifier
- add training script with HF Trainer
- build FAISS retriever and generator
- provide Streamlit demo app
- update README with usage instructions

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688541539a6c8321bc97c08f7e32cbe2

## Summary by Sourcery

Introduce an end-to-end sentiment analysis and context-aware generation pipeline, including data utilities, PEFT-based model training, FAISS retrieval, generation module, and a Streamlit demo app

New Features:
- Add data loading utilities and tokenizer helper for the IMDB dataset
- Integrate a LoRA-based DistilBERT sentiment classifier with a Hugging Face Trainer script
- Implement FAISS-backed retriever and context-aware text generation pipeline
- Provide a Streamlit application to train the model, build retrieval, and generate responses

Documentation:
- Update README with installation steps and usage examples